### PR TITLE
conditionally renders most upcoming event

### DIFF
--- a/src/components/events/EventList.js
+++ b/src/components/events/EventList.js
@@ -2,6 +2,23 @@ import React, { Component } from 'react'
 import './event.css'
 
 export default class EventList extends Component {
+
+
+    //Finds the most upcoming date in relation to the current date/time
+    findUpcoming = () => {
+        let currDate = Date.now();
+        let testArr = this.props.events.map(event => { return Date.parse(event.date) })
+        testArr.push(currDate)
+        testArr.sort((a, b) => a - b)
+        let date = new Date(currDate)
+
+        let dateAfterIndex = testArr.indexOf(currDate) + 1
+        let dateAfter = new Date(testArr[dateAfterIndex])
+        let findDate = this.props.events.find(event => Date.parse(event.date) === Date.parse(dateAfter))
+        return findDate
+
+    }
+
     render() {
         return (
             <React.Fragment>
@@ -15,15 +32,29 @@ export default class EventList extends Component {
                         }>Create New Event</button>
                     </div>
                     {
-                        this.props.events.map(event =>
+                        this.props.events.map((event, index) =>
                             <div key={event.id}>
                                 <div className="card events">
                                     <div className="card-body">
-                                        <h3 className="card-title">
-                                            {event.event}
-                                        </h3>
+
+                                        {
+                                            //conditionally renders event that is coming up the soonest
+                                            (event === this.findUpcoming()) ?
+                                                (
+                                                    <h1 className="card-title">
+                                                        {event.event}
+                                                    </h1>
+                                                )
+                                                :
+                                                (
+                                                    <h5 className="card-title">
+                                                        {event.event}
+                                                    </h5>
+                                                )
+                                        }
                                         <div className="card-text">Where: {event.location}</div>
                                         <div className="card-text">When: {event.date}</div>
+
                                         <button className="btn btn-primary"
                                             type="button"
                                             onClick={() => {
@@ -37,7 +68,7 @@ export default class EventList extends Component {
                     }
                     {
                         this.props.friendsEvents.map(event =>
-                            event.map(entry => 
+                            event.map(entry =>
                                 <div key={entry.id}>
                                     <div className="card events">
                                         <div className="card-body friendEvents">


### PR DESCRIPTION
# Description

An event that is closest to the current date/time should render with text that is bolder than the rest.

Applies to issue # 3

## Type of change

- [ ] New feature (non-breaking change which adds functionality)


# Testing Instructions

1. `git fetch`
2. `git checkout sb-style-it`
3. `npm start`
4. navigate to the events tab.
5. Add an event that is two days after the current date. That should be bold.
6. Add another event that is ONE day after the current date.
That should now be bold and the one that is two days after the current date should no longer be bold.

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added test instructions that prove my fix is effective or that my feature works
